### PR TITLE
fix: don't repair jetpack wheels

### DIFF
--- a/.github/workflows/pr_stage_test.yml
+++ b/.github/workflows/pr_stage_test.yml
@@ -115,7 +115,7 @@ jobs:
           path: code-coverage-results.md
 
   build_cu118:
-    runs-on: ubuntu-22.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
       image: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
     env:

--- a/.github/workflows/pr_stage_test.yml
+++ b/.github/workflows/pr_stage_test.yml
@@ -150,10 +150,32 @@ jobs:
       - name: Clean up apt cache and pip cache
         run: |
           apt-get clean
+          apt-get autoclean
+          apt-get autoremove -y
           rm -rf /var/lib/apt/lists/*
+          rm -rf /var/cache/apt/*
           rm -rf ~/.cache/pip
           rm -rf /root/.cache/pip
           rm -rf /tmp/*
+          # Additional cleanup to free more space
+          rm -rf /usr/share/doc/*
+          rm -rf /usr/share/man/*
+          rm -rf /usr/share/info/*
+          rm -rf /usr/share/locale/*
+          rm -rf /var/log/*
+          # Clean up any leftover package files
+          find /var/lib/apt -type f -delete 2>/dev/null || true
+          # Remove unnecessary locale files
+          rm -rf /usr/share/locale/*
+          # Clean up any cached files
+          find /root -name "*.pyc" -delete 2>/dev/null || true
+          find /root -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
+          # Clean up CUDA container bloat
+          rm -rf /opt/nvidia/nsight* 2>/dev/null || true
+          rm -rf /usr/local/cuda/doc* 2>/dev/null || true
+          rm -rf /usr/local/cuda/samples* 2>/dev/null || true
+          # Display available space
+          df -h
       - name: Install PyTorch
         run: |
           uv pip install torch==${{ matrix.torch }} torchvision

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,17 @@ concurrency:
 jobs:
   public-PyPI:
     # without torch
-    needs: cpu-wheelhouse
+    needs: [cpu-wheelhouse, cuda-wheelhouse, jetpack-wheelhouse]
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
-    if: startsWith(github.event.ref, 'refs/tags')
+    if: >-
+      startsWith(github.event.ref, 'refs/tags') &&
+      (
+        (needs.cpu-wheelhouse.result == 'success' || needs.cpu-wheelhouse.result == 'failure') &&
+        (needs.cuda-wheelhouse.result == 'success' || needs.cuda-wheelhouse.result == 'failure') &&
+        (needs.jetpack-wheelhouse.result == 'success' || needs.jetpack-wheelhouse.result == 'failure')
+      )
     steps:
       - uses: actions/checkout@v3
       - name: Install uv and set the python version
@@ -49,15 +55,15 @@ jobs:
         include:
           - cuda: 12.8.1
             pytorch: '2.8.0'
-            torch_cuda_arch_list:  "7.5 8.6 8.9"
+            torch_cuda_arch_list:  "7.5 8.6 8.9 9.0"
             python_version: "3.10"
           - cuda: 12.9.1
             pytorch: '2.8.0'
-            torch_cuda_arch_list:  "7.5 8.6 8.9"
+            torch_cuda_arch_list:  "7.5 8.6 8.9 9.0"
             python_version: "3.10"
           - cuda: 12.9.1
             pytorch: '2.9.0'
-            torch_cuda_arch_list:  "7.5 8.6 8.9"
+            torch_cuda_arch_list:  "7.5 8.6 8.9 9.0"
             python_version: "3.12"
     runs-on: ubuntu-24.04
     env:
@@ -259,6 +265,7 @@ jobs:
       - name: Build wheel
         run: |
           docker run --rm \
+          -e SKIP_REPAIR_WHEEL=1 \
           -v ${{ github.workspace }}/mmcv/dist:/out \
           mmcv-builder:${{ env.TAG_NAME }}-jetpack${{ matrix.jetpack }}-torch${{ env.PYTORCH }}
 

--- a/docker/build/entrypoint.sh
+++ b/docker/build/entrypoint.sh
@@ -2,15 +2,21 @@
 set -e
 
 uv build
-uvx auditwheel repair dist/*.whl -w dist/wheelhouse \
-    -z 9 \
-    --exclude libc10.so \
-    --exclude libc10_cuda.so \
-    --exclude libtorch.so \
-    --exclude libtorch_cpu.so \
-    --exclude libtorch_cuda.so \
-    --exclude libtorch_python.so \
-    --exclude libshm.so
 
-cp dist/wheelhouse/*.whl /out
+
+# By default, run auditwheel repair unless SKIP_REPAIR_WHEEL=1 is set
+if [ "$SKIP_REPAIR_WHEEL" = "1" ]; then
+    cp dist/*.whl /out
+else
+    uvx auditwheel repair dist/*.whl -w dist/wheelhouse \
+        -z 9 \
+        --exclude libc10.so \
+        --exclude libc10_cuda.so \
+        --exclude libtorch.so \
+        --exclude libtorch_cpu.so \
+        --exclude libtorch_cuda.so \
+        --exclude libtorch_python.so \
+        --exclude libshm.so
+    cp dist/wheelhouse/*.whl /out
+fi
 cp dist/*.tar.gz /out

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,12 @@ import glob
 import os
 import platform
 import re
-from setuptools import find_packages, setup
+from setuptools import Command, find_packages, setup
+from typing import Dict, Type
 
 from packaging.version import parse as parse_version
 
+cmd_class: Dict[str, Type[Command]]
 EXT_TYPE = ''
 try:
     import torch
@@ -372,5 +374,5 @@ def get_extensions():
 setup(
     packages=find_packages(),
     ext_modules=get_extensions(),
-    cmdclass=cmd_class,
+    cmdclass=cmd_class,  # type: ignore[arg-type]
     zip_safe=False)


### PR DESCRIPTION
build: only publish to pypi once wheels are built

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Jetpack wheels that are repaired get a manylinux tag. These wheels are then not picked up as installable on actual jetpacks.

Also: only publish the onedl-mmcv package to pypi once all wheelhouse builds are completed.

## Modification

Change wheelhouse job to not repair the jetpack built wheels.

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/vbti-development/onedl-mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/vbti-development/onedl-mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like onedl-mmdetection or onedl-mpretrain.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
