### PR TITLE
Fallback to PyTorch implementation for bf16 MultiScaleDeformableAtten

### DIFF
--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -367,11 +367,20 @@ class MultiScaleDeformableAttention(BaseModule):
         if ((IS_CUDA_AVAILABLE and value.is_cuda)
                 or (IS_MLU_AVAILABLE and value.is_mlu)
                 or (IS_MUSA_AVAILABLE and value.is_musa)
-                or (IS_NPU_AVAILABLE and value.device.type == 'npu')):
+                or (IS_NPU_AVAILABLE and value.device.type == 'npu'))\
+                and value.dtype != torch.bfloat16:
             output = MultiScaleDeformableAttnFunction.apply(
                 value, spatial_shapes, level_start_index, sampling_locations,
                 attention_weights, self.im2col_step)
         else:
+            if ((IS_CUDA_AVAILABLE and value.is_cuda)
+                or (IS_MLU_AVAILABLE and value.is_mlu)
+                or (IS_MUSA_AVAILABLE and value.is_musa)
+                or (IS_NPU_AVAILABLE and value.device.type == 'npu'))\
+                and value.dtype == torch.bfloat16:
+                warnings.warn(
+                    'MultiScaleDeformableAttnFunction does not support torch.bfloat16. '
+                    'Falling back to the PyTorch implementation.')
             output = multi_scale_deformable_attn_pytorch(
                 value, spatial_shapes, sampling_locations, attention_weights)
 

--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -364,23 +364,19 @@ class MultiScaleDeformableAttention(BaseModule):
             raise ValueError(
                 f'Last dim of reference_points must be'
                 f' 2 or 4, but get {reference_points.shape[-1]} instead.')
-        if ((IS_CUDA_AVAILABLE and value.is_cuda)
-                or (IS_MLU_AVAILABLE and value.is_mlu)
-                or (IS_MUSA_AVAILABLE and value.is_musa)
-                or (IS_NPU_AVAILABLE and value.device.type == 'npu'))\
-                and value.dtype != torch.bfloat16:
+        use_custom_op = ((IS_CUDA_AVAILABLE and value.is_cuda)
+                         or (IS_MLU_AVAILABLE and value.is_mlu)
+                         or (IS_MUSA_AVAILABLE and value.is_musa)
+                         or (IS_NPU_AVAILABLE and value.device.type == 'npu'))
+        if use_custom_op and value.dtype != torch.bfloat16:
             output = MultiScaleDeformableAttnFunction.apply(
                 value, spatial_shapes, level_start_index, sampling_locations,
                 attention_weights, self.im2col_step)
         else:
-            if ((IS_CUDA_AVAILABLE and value.is_cuda)
-                or (IS_MLU_AVAILABLE and value.is_mlu)
-                or (IS_MUSA_AVAILABLE and value.is_musa)
-                or (IS_NPU_AVAILABLE and value.device.type == 'npu'))\
-                and value.dtype == torch.bfloat16:
-                warnings.warn(
-                    'MultiScaleDeformableAttnFunction does not support torch.bfloat16. '
-                    'Falling back to the PyTorch implementation.')
+            if use_custom_op and value.dtype == torch.bfloat16:
+                warnings.warn('MultiScaleDeformableAttnFunction does not '
+                              'support torch.bfloat16. '
+                              'Falling back to the PyTorch implementation.')
             output = multi_scale_deformable_attn_pytorch(
                 value, spatial_shapes, sampling_locations, attention_weights)
 


### PR DESCRIPTION
…tion (#44)

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`bfloat16` is useful for AMP training because it has a larger exponent range than `float16`, which can reduce the risk of overflow and `NaN` loss during training.

For Mask2Former and other models that rely on multi-scale deformable attention, supporting a bf16 fallback path would make AMP training more stable and practical, while avoiding changes to the CUDA kernel itself.

## Modification

This PR  add a dtype check in `MultiScaleDeformableAttention`.

The PR would not add bf16 support to the CUDA operator directly. Instead, when the input dtype is `torch.bfloat16`, it would use the existing PyTorch implementation as a fallback.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/vbti-development/onedl-mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/vbti-development/onedl-mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like onedl-mmdetection or onedl-mpretrain.
