### PR TITLE
chore: update jetpack build with torch 2.11 for numpy 2 support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,6 +32,7 @@ coverage.xml
 .github/
 .pre-commit-config.yaml
 .devcontainer/
+.venv/
 
 docs/
 examples/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -272,7 +272,6 @@ jobs:
       - name: Build wheel
         run: |
           docker run --rm \
-          -e SKIP_REPAIR_WHEEL=1 \
           -v ${{ github.workspace }}/mmcv/dist:/out \
           mmcv-builder:${{ env.TAG_NAME }}-jetpack${{ matrix.jetpack }}-torch${{ env.PYTORCH }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -231,15 +231,15 @@ jobs:
           --endpoint-url ${{ secrets.WHEELHOUSE_S3_ENDPOINT }} \
           --exclude '.gitignore'
 
-  # JetPack 6.0 wheel build for ARM64 devices (CUDA 12.2.1, PyTorch 2.8.0)
+  # JetPack 6.1 wheel build for ARM64 devices (CUDA 12.2.1, PyTorch 2.11.0)
   jetpack-wheelhouse:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
-        jetpack: ['60', '61']
+        jetpack: ['61']
     env:
-      PYTORCH: '2.8.0' # hardcoded in Dockerfiles
+      PYTORCH: '2.11.0' # hardcoded in Dockerfiles
     steps:
       - uses: actions/checkout@v5
 

--- a/docker/build/Dockerfile.jetpack61
+++ b/docker/build/Dockerfile.jetpack61
@@ -36,7 +36,7 @@ ENV UV_LINK_MODE=copy
 # install torch
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip \
     uv pip install --no-cache \
-    https://pypi.jetson-ai-lab.io/jp6/cu126/+f/62a/1beee9f2f1470/torch-2.8.0-cp310-cp310-linux_aarch64.whl#sha256=62a1beee9f2f147076a974d2942c90060c12771c94740830327cae705b2595fc
+    https://pypi.jetson-ai-lab.io/jp6/cu126/+f/46b/b8b13f844b211/torch-2.11.0-cp310-cp310-linux_aarch64.whl#sha256=46bb8b13f844b2111f6f41abc703d01075a7185e0c587cb002e957ede2b8c8a3
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install setuptools && uv sync --group build --group optional --no-install-project --inexact

--- a/docker/build/Dockerfile.jetpack61
+++ b/docker/build/Dockerfile.jetpack61
@@ -35,7 +35,7 @@ RUN git clone --single-branch https://github.com/vbti-development/onedl-mmcv.git
 ENV UV_LINK_MODE=copy
 # install torch
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip \
-    uv pip install --no-cache \
+    uv pip install \
     https://pypi.jetson-ai-lab.io/jp6/cu126/+f/46b/b8b13f844b211/torch-2.11.0-cp310-cp310-linux_aarch64.whl#sha256=46bb8b13f844b2111f6f41abc703d01075a7185e0c587cb002e957ede2b8c8a3
 
 RUN --mount=type=cache,target=/root/.cache/uv \


### PR DESCRIPTION
- remove jetpack 6.0 support

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

On jetpack running mmcv fails because torch there was compile with numpy 1. Updating torch fixes it.

## Modification

- Update torch version in jetpack 6.1 build
- drop support for jetpack 6.0

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/vbti-development/onedl-mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/vbti-development/onedl-mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like onedl-mmdetection or onedl-mpretrain.
